### PR TITLE
`.eft <item>` improvements

### DIFF
--- a/src/errbot/plugins/eft/eft.py
+++ b/src/errbot/plugins/eft/eft.py
@@ -363,6 +363,7 @@ class Eft(BotPlugin):
         # Hardcoded name overrides for popular items
         item, hard_coded = self.item_hard_code_replacer(item)
 
+        # Fetch close matches to the item name to help users who might have requested a slightly different item
         item_matches = util.close_matches(item, self.item_names, cutoff=0.5)
 
         alt_matches = None
@@ -395,9 +396,7 @@ class Eft(BotPlugin):
             message = f"The item you requested `{args}` was not found."
             if alt_matches:
                 message += f"I found some similar items: {alt_matches}"
-            self.general_error(
-                msg, "Not found", message
-            )
+            self.general_error(msg, "Not found", message)
             return
 
         # Format the types to be wrapped in backticks to look pretty
@@ -415,7 +414,7 @@ class Eft(BotPlugin):
         body += f"• Wiki: {result_data['link']}\n"
         body += f"• Item Tier: {item_tier['msg']}\n"
         body += f"• Sell to: `{trader}` for `{self.fmt_number(highest_price)}`\n"
-        
+
         if alt_matches:
             body += f"\n**Other items with similar names:**{alt_matches}\n"
 
@@ -782,7 +781,7 @@ class Eft(BotPlugin):
                 return "TerraGroup Labs keycard (Black)", True
         if item == "gpu":
             return "Graphics card", True
-        
+
         # If no matches are found, return the original item name
         return item, False
 
@@ -803,7 +802,9 @@ class Eft(BotPlugin):
 
             item_names = []
             for _, value in self.item_data.items():
-                item_names.append(value['name'].encode('ascii', 'ignore').decode('ascii'))
+                item_names.append(
+                    value["name"].encode("ascii", "ignore").decode("ascii")
+                )
             self.item_names = item_names
 
             # Update cache

--- a/src/errbot/plugins/eft/eft.py
+++ b/src/errbot/plugins/eft/eft.py
@@ -74,6 +74,7 @@ class Eft(BotPlugin):
         self.eft_cache_time = None
         self.ammo_data = {}
         self.item_data = {}
+        self.item_names = []
 
     def activate(self):
         """
@@ -665,7 +666,7 @@ class Eft(BotPlugin):
         elif len(ammo_matches) >= 1:
             ammo_type = ammo_matches[0]
 
-        # If we don't have the cached ammo_data and its not fresh, fetch it
+        # If we don't have the cached ammo_data or its not fresh, fetch it
         if (
             not self.ammo_data
             or self.eft_cache_time is None
@@ -771,12 +772,20 @@ class Eft(BotPlugin):
                 "https://raw.githubusercontent.com/TarkovTracker/tarkovdata/master/items.en.json"
             ).json()
 
+            item_names = []
+            for _, value in self.item_data.items():
+                item_names.append(value['name'].encode('ascii', 'ignore').decode('ascii'))
+            self.item_names = item_names
+
             # Update cache
             self.eft_cache_time = util.parse_iso_timestamp(util.iso_timestamp())
+
+            self.log.info("eft cache data successfully refreshed")
 
             return True
         except Exception as error:
             ErrHelper().capture(error)
+            self.log.error("failed to refresh the eft cache")
             return False
 
     def map_help(self, msg):
@@ -908,7 +917,7 @@ class Eft(BotPlugin):
         :return: True if the input is valid, False if not
         """
         # Character Allow List
-        regex = r"^[a-zA-Z\d\s-]+$"
+        regex = r"^[a-zA-Z\d\()\s-]+$"
 
         # If there is a match the input is valid and we can return true
         if re.match(regex, args):

--- a/src/errbot/plugins/eft/eft.py
+++ b/src/errbot/plugins/eft/eft.py
@@ -72,7 +72,8 @@ class Eft(BotPlugin):
         """
         super().__init__(bot, name)
         self.eft_cache_time = None
-        self.ammo_data = self.get_ammo_data()
+        self.ammo_data = {}
+        self.item_data = {}
 
     def activate(self):
         """
@@ -641,7 +642,7 @@ class Eft(BotPlugin):
             )
             == True
         ):
-            self.ammo_data = self.get_ammo_data()
+            self.refresh_eft_data()
 
         # Loop through and collect data on the selected ammo type
         ammo_list = []
@@ -723,20 +724,25 @@ class Eft(BotPlugin):
         )
         return tarkov_time.strftime("%H:%M:%S")
 
-    def get_ammo_data(self):
+    def refresh_eft_data(self):
         """
-        Helper function to get the ammo data from GitHub
-        :return ammo_data: Returns the ammo data from GitHub (json) - False if failed
+        Helper function to refresh static eft data from GitHub - That can be cached in memory
+        :return bool: True is successful, False if not
         """
         try:
-            ammo_data = requests.get(
+            # Update static ammo data
+            self.ammo_data = requests.get(
                 "https://raw.githubusercontent.com/TarkovTracker/tarkovdata/master/ammunition.json"
             ).json()
+            # Update static item data
+            self.item_data = requests.get(
+                "https://raw.githubusercontent.com/TarkovTracker/tarkovdata/master/items.en.json"
+            ).json()
 
-            # Update the ammo data cache
+            # Update cache
             self.eft_cache_time = util.parse_iso_timestamp(util.iso_timestamp())
 
-            return ammo_data
+            return True
         except Exception as error:
             ErrHelper().capture(error)
             return False

--- a/src/errbot/plugins/eft/eft.py
+++ b/src/errbot/plugins/eft/eft.py
@@ -57,7 +57,7 @@ MAPS = [
     {"name": "interchange", "players": "10-14", "duration": "45"},
 ]
 MAP_DIR = "plugins/eft/maps"
-AMMO_CACHE_TIME = 3600  # 1 hour
+EFT_CACHE_TIME = 3600  # 1 hour
 INTERVAL = 300  # 5 minutes
 
 
@@ -67,9 +67,11 @@ class Eft(BotPlugin):
     def __init__(self, bot, name=None):
         """
         Initialize the plugin with its class variables
+        Note: self.eft_cache_time is used to check the cache time of eft ammo types and items...
+        ...This does not need to be constantly refreshed as updates releasing new items and ammo types is not frequent
         """
         super().__init__(bot, name)
-        self.ammo_cache_time = None
+        self.eft_cache_time = None
         self.ammo_data = self.get_ammo_data()
 
     def activate(self):
@@ -633,9 +635,9 @@ class Eft(BotPlugin):
         # If we don't have the cached ammo_data and its not fresh, fetch it
         if (
             not self.ammo_data
-            or self.ammo_cache_time is None
+            or self.eft_cache_time is None
             or util.is_timestamp_older_than_n_seconds(
-                self.ammo_cache_time, AMMO_CACHE_TIME
+                self.eft_cache_time, EFT_CACHE_TIME
             )
             == True
         ):
@@ -732,7 +734,7 @@ class Eft(BotPlugin):
             ).json()
 
             # Update the ammo data cache
-            self.ammo_cache_time = util.parse_iso_timestamp(util.iso_timestamp())
+            self.eft_cache_time = util.parse_iso_timestamp(util.iso_timestamp())
 
             return ammo_data
         except Exception as error:


### PR DESCRIPTION
# `.eft <item>` improvements 🔍 

It has been requested by many folks to improve the search capabilities of the `.eft <item>` command. Most notably, having "similar" results returned for queries where the exact match you are looking for wasn't found. This pull request does exactly that!

It also hardcodes some items to their matched names. For example, neither the graphQL API for Tarkov data, or the `get_close_matches()` Python method will return a match for the following query: `.eft gpu`. That is because `gpu` is not a valid item even though it what the player base largely refers to it as. The "hardcoded" matches account for this and we can add more as we need to.

---

## Features ⭐ 

- 🎯 More accurate item lookups
- 🔍 Close item matches are returned in results if multiple items match on your query
- 🙃 Hardcoded item matches for eft lingo, shorthand item names, nick-names, or difficult matches

---

## Examples 📸 

Tarkov API failing to get a really botched item name:

![image](https://user-images.githubusercontent.com/23362539/156719358-98a93ca4-392d-4c1d-b52b-173806f864b5.png)

Errbot succeeding:

![image](https://user-images.githubusercontent.com/23362539/156719409-4457b1fb-6db3-42da-9099-85a74a01f828.png)

