### PR TITLE
use latest `yt-dlp` and `youtube-search-python`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ riotwatcher==3.1.3
 PyNaCl==1.4.0
 pynamodb==5.1.0
 boto3==1.18.29
-yt-dlp==2021.11.10.1
+yt-dlp==2022.7.18
 youtube-search-python==1.5.1
 spotipy==2.19.0
 gTTS==2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ PyNaCl==1.4.0
 pynamodb==5.1.0
 boto3==1.18.29
 yt-dlp==2022.7.18
-youtube-search-python==1.5.1
+youtube-search-python==1.6.6
 spotipy==2.19.0
 gTTS==2.2.3
 validators==0.18.2

--- a/src/errbot/requirements.txt
+++ b/src/errbot/requirements.txt
@@ -14,13 +14,13 @@ pynamodb==5.1.0
 boto3==1.18.29
 
 # yt-dlp / youtube-dl
-yt-dlp==2022.4.8
+yt-dlp==2022.7.18
 
 # soundcloud downloader
 scdl==2.7.1
 
 # youtube string searching
-youtube-search-python==1.5.1
+youtube-search-python==1.6.6
 
 # spotipy
 spotipy==2.19.0


### PR DESCRIPTION
# use latest `yt-dlp` and `youtube-search-python`

This pull requests uses the latest version of `yt-dlp`

This PR also bumps the `youtube-search-python` lib to the latest and sadly the last supported version